### PR TITLE
allow abstract controller to exist

### DIFF
--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -60,7 +60,6 @@ class Metadata
                     try {
                         $c = Yii::$app->createController($route);
                     } catch (NotInstantiableException $exception) {
-                        Yii::error($exception->getMessage());
                         $c = false;
                     }
 

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -4,6 +4,7 @@ namespace dmstr\helpers;
 
 use Yii;
 use yii\base\Module;
+use yii\di\NotInstantiableException;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Inflector;
 
@@ -55,7 +56,14 @@ class Metadata
                     $route .= (!$directory) ? '' : '/'.$directory;
                     $route .= '/' . $controller;
 
-                    $c = Yii::$app->createController($route);
+                    // check if controller not is abstract
+                    try {
+                        $c = Yii::$app->createController($route);
+                    } catch (NotInstantiableException $exception) {
+                        Yii::error($exception->getMessage());
+                        $c = false;
+                    }
+
                     if ($c === false) {
                         continue;
                     }


### PR DESCRIPTION
Currently an `yii\di\NotInstantiableException` will be thrown if there is an abstract controller. 

This could be a bit impractical if you have e.g. BaseController or similar which acts as an abstract parent for the other controllers. 